### PR TITLE
Add roles declarations to forbid unsafe coercions

### DIFF
--- a/src/Effect/Aff/Bus.purs
+++ b/src/Effect/Aff/Bus.purs
@@ -31,6 +31,8 @@ data Cap
 
 data Bus (r ∷ # Type) a = Bus (AVar a) (AVar (List (AVar a)))
 
+type role Bus nominal representational
+
 type BusR = BusR' ()
 
 type BusR' r = Bus (read ∷ Cap | r)


### PR DESCRIPTION
This prevents terms of type `Bus cap1 a` to be coerced to type `Bus cap2 b` but allows to coerce terms of type `Bus cap a` to type `Bus cap b` when `Coercible a b` holds, hence allowing the zero cost `coerce` to read and write newtypes from/to a bus for instance. The nominal role ensures a readonly bus cannot be coerced to a readwrite or a writable one.