### PR TITLE
Add missing deps

### DIFF
--- a/spago.dhall
+++ b/spago.dhall
@@ -1,6 +1,20 @@
 { name = "aff-bus"
 , dependencies =
-  [ "avar", "console", "effect", "prelude", "psci-support", "refs" ]
+  [ "aff"
+  , "avar"
+  , "console"
+  , "effect"
+  , "either"
+  , "exceptions"
+  , "foldable-traversable"
+  , "lists"
+  , "prelude"
+  , "psci-support"
+  , "refs"
+  , "tailrec"
+  , "transformers"
+  , "tuples"
+  ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -36,7 +36,7 @@ test_readWrite bus = do
     proc = do
       res ← attempt (Bus.read bus)
       case res of
-        Left e  → do
+        Left _  → do
           void $ liftEffect $ Ref.modify (_ + 100) ref
         Right n → do
           void $ liftEffect $ Ref.modify (_ + n) ref
@@ -56,7 +56,7 @@ test_readWrite bus = do
   Bus.kill err bus
   attempt (Bus.read bus) >>= case _ of
     Left err' | show err' == show err -> pure unit
-    oop -> throwError $ error "read from killed bus should resolve with same error which was used to kill"
+    _ -> throwError $ error "read from killed bus should resolve with same error which was used to kill"
   unlessM (Bus.isKilled bus) $ throwError $ error "isKilled must return true as bus was killed"
   
 


### PR DESCRIPTION
**Description of the change**

This adds missing dependencies listed when running `spago build` (see: https://github.com/purescript-contrib/governance/issues/43)

<details><summary>Output from running <code>spago build</code> before these changes</summary>

<pre>
[info] Build succeeded.
[error] Some of your project files import modules from packages that are not in the direct dependencies of your project.
To fix this error add the following packages to the list of dependencies in your config:
- aff
- either
- exceptions
- foldable-traversable
- lists
- tailrec
- transformers
- tuples
You may add these dependencies by running the following command:
spago install aff either exceptions foldable-traversable lists tailrec transformers tuples
</pre>

</details>

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
