### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up a PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -32,3 +34,6 @@ jobs:
 
       - name: Run tests
         run: spago test --no-install
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 
 output
 generated-docs

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Added `purs-tidy` formatter (#24 by @thomashoneyman)
 
 ## [v5.0.1](https://github.com/purescript-contrib/purescript-aff-bus/releases/tag/v5.0.1) - 2021-11-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
-- Added `purs-tidy` formatter (#24 by @thomashoneyman)
+- Added `purs-tidy` formatter (#30 by @thomashoneyman)
 
 ## [v5.0.1](https://github.com/purescript-contrib/purescript-aff-bus/releases/tag/v5.0.1) - 2021-11-09
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -28,22 +28,22 @@ import Effect.Ref as Ref
 import Control.Monad.Error.Class (throwError)
 import Data.Either (Either(..), either)
 
-test_readWrite ∷ Bus.BusRW Int -> Aff Boolean
+test_readWrite :: Bus.BusRW Int -> Aff Boolean
 test_readWrite bus = do
-  ref ← liftEffect $ Ref.new 0
+  ref <- liftEffect $ Ref.new 0
 
   let
     proc = do
-      res ← attempt (Bus.read bus)
+      res <- attempt (Bus.read bus)
       case res of
-        Left _  → do
+        Left _ -> do
           void $ liftEffect $ Ref.modify (_ + 100) ref
-        Right n → do
+        Right n -> do
           void $ liftEffect $ Ref.modify (_ + n) ref
           proc
 
-  f1 ← forkAff proc
-  f2 ← forkAff proc
+  f1 <- forkAff proc
+  f2 <- forkAff proc
 
   Bus.write 1 bus
   Bus.write 2 bus
@@ -58,7 +58,6 @@ test_readWrite bus = do
     Left err' | show err' == show err -> pure unit
     _ -> throwError $ error "read from killed bus should resolve with same error which was used to kill"
   unlessM (Bus.isKilled bus) $ throwError $ error "isKilled must return true as bus was killed"
-  
 
   joinFiber f1
   joinFiber f2
@@ -66,8 +65,7 @@ test_readWrite bus = do
   res <- liftEffect $ Ref.read ref
   pure $ res == 212
 
-
-main ∷ Effect Unit
+main :: Effect Unit
 main = do
   log "Testing read/write/kill..."
   runTest $ Bus.make >>= test_readWrite
@@ -84,8 +82,7 @@ main = do
     isOk isFinishedRef = case _ of
       Left err -> throwException err
       Right res ->
-        if res
-          then do
-            log "ok"
-            Ref.write true isFinishedRef
-          else throwException $ error "failed"
+        if res then do
+          log "ok"
+          Ref.write true isFinishedRef
+        else throwException $ error "failed"


### PR DESCRIPTION
**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
